### PR TITLE
Initial scale kept for first minute of experiment

### DIFF
--- a/pkg/driver/deploy.sh
+++ b/pkg/driver/deploy.sh
@@ -31,7 +31,6 @@ export CPU_REQUEST=$3
 export CPU_LIMITS=$4
 export MEMORY_REQUESTS=$5
 export INIT_SCALE=$6
-
 export MIN_SCALE=$6 # minimum scale is the same as initial scale during profiling
 
 export PANIC_WINDOW=$7

--- a/pkg/driver/deployment.go
+++ b/pkg/driver/deployment.go
@@ -112,12 +112,11 @@ func deployOne(function *common.Function, yamlPath string, isPartiallyPanic bool
 	return true
 }
 
-func UpdateFunctionKnative(function *common.Function, yamlPath string, endpointPort int) bool {
+func UpdateFunctionKnative(function *common.Function, endpointPort int) bool {
 
 	cmd := exec.Command(
 		"bash",
 		"./pkg/driver/update_deployment.sh",
-		yamlPath,
 		function.Name,
 	)
 

--- a/pkg/driver/trace_driver.go
+++ b/pkg/driver/trace_driver.go
@@ -376,7 +376,7 @@ func (d *Driver) proceedToNextMinute(function *common.Function, minuteIndex *int
 	if d.Configuration.WithWarmup() && *minuteIndex == 1 {
 		log.Info("profiling phase is done, updating deployments to allow downscaling below initial scale.")
 		if d.Configuration.LoaderConfiguration.Platform == "Knative" {
-			UpdateFunctionKnative(function, d.Configuration.YAMLPath, d.Configuration.LoaderConfiguration.EndpointPort)
+			UpdateFunctionKnative(function, d.Configuration.LoaderConfiguration.EndpointPort)
 		}
 	}
 	if d.Configuration.WithWarmup() && *minuteIndex == (d.Configuration.LoaderConfiguration.WarmupDuration+1) {

--- a/pkg/driver/trace_driver_test.go
+++ b/pkg/driver/trace_driver_test.go
@@ -318,9 +318,9 @@ func TestDriverCompletely(t *testing.T) {
 				record := records[i]
 
 				if test.withWarmup {
-					if i < 5 && record.Phase != int(common.WarmupPhase) {
+					if i < 10 && record.Phase != int(common.WarmupPhase) {
 						t.Error("Invalid record phase in warmup.")
-					} else if i > 5 && record.Phase != int(common.ExecutionPhase) {
+					} else if i >= 10 && record.Phase != int(common.ExecutionPhase) {
 						t.Error("Invalid record phase in execution phase.")
 					}
 				}
@@ -342,7 +342,7 @@ func TestDriverCompletely(t *testing.T) {
 
 			expectedInvocations := 5
 			if test.withWarmup {
-				expectedInvocations = 10
+				expectedInvocations = 15
 			}
 
 			if !(successfulInvocation == expectedInvocations && failedInvocations == 0) {

--- a/pkg/driver/update_deployment.sh
+++ b/pkg/driver/update_deployment.sh
@@ -24,7 +24,6 @@
 # SOFTWARE.
 #
 
-CONFIG_FILE=$1
-export FUNC_NAME=$2
+export FUNC_NAME=$1
 
 kn service update $FUNC_NAME --scale-min 0 --scale-init 0

--- a/pkg/driver/update_deployment.sh
+++ b/pkg/driver/update_deployment.sh
@@ -27,17 +27,4 @@
 CONFIG_FILE=$1
 export FUNC_NAME=$2
 
-export CPU_REQUEST=$3
-export CPU_LIMITS=$4
-export MEMORY_REQUESTS=$5
-export INIT_SCALE=$6
-
-export MIN_SCALE=$6 # minimum scale is the same as initial scale during profiling
-
-export PANIC_WINDOW=$7
-export PANIC_THRESHOLD=$8
-
-export AUTOSCALING_METRIC=$9
-export AUTOSCALING_TARGET=${10}
-
-cat $CONFIG_FILE | envsubst | kn service apply $FUNC_NAME --concurrency-target 1 --wait-timeout 2000000 -f /dev/stdin
+kn service update $FUNC_NAME --scale-min 0 --scale-init 0

--- a/workloads/container/trace_func_go.yaml
+++ b/workloads/container/trace_func_go.yaml
@@ -7,8 +7,8 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/initial-scale: "0"  # Should start from 0, otherwise we can't deploy more functions than the node physically permits.
-        autoscaling.knative.dev/min-scale: "0"  # This parameter only has a per-revision key, so it's necessary to have here in case of the warmup messes up.
+        autoscaling.knative.dev/initial-scale: $INIT_SCALE # Should start from 0, otherwise we can't deploy more functions than the node physically permits.
+        autoscaling.knative.dev/min-scale: $MIN_SCALE  # This parameter only has a per-revision key, so it's necessary to have here in case of the warmup messes up.
         autoscaling.knative.dev/target-utilization-percentage: "100"  # Enforce container concurrency at any time.
         autoscaling.knative.dev/target-burst-capacity: "-1"  # Put activator always in the path explicitly.
         autoscaling.knative.dev/max-scale: "200"  # Maximum instances limit of Azure.


### PR DESCRIPTION
## Summary

The initial scale set by the profiling should be kept until the start of the warmup phase.

## Implementation Notes :hammer_and_pick:

* For the first minute, there is a minimum scale equal to the initial scale determined by the profiling phase. After that minute, we update the revisions to set the initial and minimum scale to 0.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*
