### PR TITLE
Fix end-to-end test setup

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,6 +55,8 @@ jobs:
           KNATIVE_DOMAIN=$INGRESS_HOST.sslip.io
           kubectl patch configmap -n knative-serving config-domain -p "{\"data\": {\"$KNATIVE_DOMAIN\": \"\"}}"
           kubectl patch configmap -n knative-serving config-autoscaler -p "{\"data\": {\"allow-zero-initial-scale\": \"true\"}}"
+          kubectl patch configmap -n knative-serving config-features -p "{\"data\": {\"kubernetes.podspec-nodeselector\": \"enabled\"}}"
+          kubectl label node knative-control-plane loader-nodetype=worker
 
       - name: Build and run loader
         run: go run cmd/loader.go --config cmd/config.json

--- a/cmd/config.json
+++ b/cmd/config.json
@@ -10,7 +10,7 @@
   "Granularity": "minute",
   "OutputPathPrefix": "data/out/experiment",
   "IATDistribution": "exponential",
-  "ExperimentDuration": 45,
+  "ExperimentDuration": 2,
   "WarmupDuration": 0,
 
   "IsPartiallyPanic": false,

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -51,7 +51,7 @@ func TestConfigParser(t *testing.T) {
 		!strings.HasPrefix(config.OutputPathPrefix, "data/out/experiment") ||
 		config.Granularity != "minute" ||
 		config.IATDistribution != "exponential" ||
-		config.ExperimentDuration != 45 ||
+		config.ExperimentDuration != 2 ||
 		config.WarmupDuration != 0 ||
 		config.IsPartiallyPanic != false ||
 		config.EnableZipkinTracing != false ||


### PR DESCRIPTION
## Summary

End to end tests are failing after introduction of labels (#136). This fixes part of #248.

## Implementation Notes :hammer_and_pick:

* Enable NodeSelector in testbed and label the node to accommodate the function.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A